### PR TITLE
解决windows、Linux系统使用normalize路径分隔符不一致的问题

### DIFF
--- a/03-middleware/src/middlewares/urlnormalize.js
+++ b/03-middleware/src/middlewares/urlnormalize.js
@@ -3,7 +3,8 @@ const { parse, format } = require('url');
 
 module.exports = function urlnormalizeMiddleware() {
   return (req, res, next) => {
-    const pathname = normalize(req.path);
+    // 解决windows、Linux系统使用normalize路径分隔符不一致的问题
+    const pathname = normalize(req.path).split('\\').join('/');
     const urlParsed = parse(req.url);
 
     let shouldRedirect = false;


### PR DESCRIPTION
老哥，我才开始学node，没有什么经验，也不知道这样改有什么缺陷没有。请多多指教，谢谢！